### PR TITLE
Optimized memory usage 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@
 - Symbols for active alarms, phone connection and notifications, as well as the heart rate and recovery time indicators use icons from a [custom font];
 - On some of the newest watches, it is possible to detect touch screen presses (touch and hold). This is used for a little gimmick to change the hour and minute hands and draw just their outlines for a few seconds after a screen press, so any indicator that is covered by the hands becomes readable (supported on the Forerunner 255, 955 and fēnix 7 series and the Enduro 2);
 - A global settings class synchronises the selected options to persistent storage and makes them available across the app;
-- The program compiles without warnings with the compiler type checking level set to "Strict";
+- The program compiles with only a single warning with the compiler type checking level set to "Strict";
 - Newer ("Modern") watches with support for [layers] and sufficient memory or a graphics pool (since [Connect IQ 4.0]) use layers. Older ("Legacy") devices without layer support or insufficient memory use a buffered bitmap. The distinction is made using [Jungle file build instructions]. ```minApiLevel``` is set to 3.2.0 as that's the minimum level required for on-device settings. Devices with [AMOLED] displays are not supported.
 - Memory usage on legacy devices is now really close to the limit. I highly recommend using the [Prettier Monkey C] extension for Visual Studio Code to optimize the generated program as much as possible. (From my experience, memory usage of the optimized program is reduced by 2-4%.)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@
 - Symbols for active alarms, phone connection and notifications, as well as the heart rate and recovery time indicators use icons from a [custom font];
 - On some of the newest watches, it is possible to detect touch screen presses (touch and hold). This is used for a little gimmick to change the hour and minute hands and draw just their outlines for a few seconds after a screen press, so any indicator that is covered by the hands becomes readable (supported on the Forerunner 255, 955 and fēnix 7 series and the Enduro 2);
 - A global settings class synchronises the selected options to persistent storage and makes them available across the app;
-- The program compiles with only a single warning with the compiler type checking level set to "Strict";
+- The program compiles without warnings with the compiler type checking level set to "Strict";
 - Newer ("Modern") watches with support for [layers] and sufficient memory or a graphics pool (since [Connect IQ 4.0]) use layers. Older ("Legacy") devices without layer support or insufficient memory use a buffered bitmap. The distinction is made using [Jungle file build instructions]. ```minApiLevel``` is set to 3.2.0 as that's the minimum level required for on-device settings. Devices with [AMOLED] displays are not supported.
 - Memory usage on legacy devices is now really close to the limit. I highly recommend using the [Prettier Monkey C] extension for Visual Studio Code to optimize the generated program as much as possible. (From my experience, memory usage of the optimized program is reduced by 2-4%.)
 

--- a/source-legacy/ClockView.mc
+++ b/source-legacy/ClockView.mc
@@ -235,9 +235,9 @@ class ClockView extends WatchUi.WatchFace {
             colorMode = setColorMode(deviceSettings.doNotDisturb, clockTime.hour, clockTime.min);
 
             // Handle the setting to disable the second hand in sleep mode after some time
-            var secondsOption = $.config.getValue($.Config.I_HIDE_SECONDS);
-            _hideSecondHand = $.Config.O_HIDE_SECONDS_ALWAYS == secondsOption 
-                or ($.Config.O_HIDE_SECONDS_IN_DM == secondsOption and M_DARK == colorMode);
+            var secondsOption = $.config.getOption($.Config.I_HIDE_SECONDS);
+            _hideSecondHand = :HideSecondsAlways == secondsOption 
+                or (:HideSecondsInDm == secondsOption and M_DARK == colorMode);
 
             // Draw the background
             if (System.SCREEN_SHAPE_ROUND == _screenShape) {
@@ -486,21 +486,21 @@ class ClockView extends WatchUi.WatchFace {
 
     private function setColorMode(doNotDisturb as Boolean, hour as Number, min as Number) as Number {
         var colorMode = M_LIGHT;
-        switch ($.config.getValue($.Config.I_DARK_MODE)) {
-            case $.Config.O_DARK_MODE_SCHEDULED:
+        switch ($.config.getOption($.Config.I_DARK_MODE)) {
+            case :DarkModeScheduled:
                 colorMode = M_LIGHT;
                 var time = hour * 60 + min;
                 if (time >= $.config.getValue($.Config.I_DM_ON) or time < $.config.getValue($.Config.I_DM_OFF)) {
                     colorMode = M_DARK;
                 }
                 break;
-            case $.Config.O_DARK_MODE_OFF:
+            case :Off:
                 colorMode = M_LIGHT;
                 break;
-            case $.Config.O_DARK_MODE_ON:
+            case :On:
                 colorMode = M_DARK;
                 break;
-            case $.Config.O_DARK_MODE_IN_DND:
+            case :DarkModeInDnD:
                 colorMode = doNotDisturb ? M_DARK : M_LIGHT;
                 break;
         }

--- a/source-legacy/ClockView.mc
+++ b/source-legacy/ClockView.mc
@@ -485,24 +485,16 @@ class ClockView extends WatchUi.WatchFace {
     }
 
     private function setColorMode(doNotDisturb as Boolean, hour as Number, min as Number) as Number {
+        var darkMode = $.config.getOption($.Config.I_DARK_MODE);
         var colorMode = M_LIGHT;
-        switch ($.config.getOption($.Config.I_DARK_MODE)) {
-            case :DarkModeScheduled:
-                colorMode = M_LIGHT;
-                var time = hour * 60 + min;
-                if (time >= $.config.getValue($.Config.I_DM_ON) or time < $.config.getValue($.Config.I_DM_OFF)) {
-                    colorMode = M_DARK;
-                }
-                break;
-            case :Off:
-                colorMode = M_LIGHT;
-                break;
-            case :On:
+        if (:DarkModeScheduled == darkMode) {
+            var time = hour * 60 + min;
+            if (time >= $.config.getValue($.Config.I_DM_ON) or time < $.config.getValue($.Config.I_DM_OFF)) {
                 colorMode = M_DARK;
-                break;
-            case :DarkModeInDnD:
-                colorMode = doNotDisturb ? M_DARK : M_LIGHT;
-                break;
+            }
+        } else if (   :On == darkMode
+                   or (:DarkModeInDnD == darkMode and doNotDisturb)) {
+            colorMode = M_DARK;
         }
         return colorMode;
     }

--- a/source-legacy/Settings.mc
+++ b/source-legacy/Settings.mc
@@ -261,32 +261,28 @@ class SettingsMenu extends WatchUi.Menu2 {
                 // Fallthrough
             case $.Config.I_BATTERY:
                 // Add menu items for the battery label options only if battery is not set to "Off"
-                if ($.Config.O_BATTERY_OFF != $.config.getValue($.Config.I_BATTERY)) {
-                    addToggleMenuItem($.Config.I_BATTERY_PCT, $.Config.O_BATTERY_PCT_ON);
+                if ($.config.isEnabled($.Config.I_BATTERY)) {
+                    addToggleMenuItem($.Config.I_BATTERY_PCT);
                     if ($.config.hasBatteryInDays()) { 
-                        addToggleMenuItem($.Config.I_BATTERY_DAYS, $.Config.O_BATTERY_DAYS_ON); 
+                        addToggleMenuItem($.Config.I_BATTERY_DAYS); 
                     }
                 }
                 addMenuItem($.Config.I_DATE_DISPLAY);
-                addToggleMenuItem($.Config.I_ALARMS, $.Config.O_ALARMS_ON);
-                addToggleMenuItem($.Config.I_NOTIFICATIONS, $.Config.O_NOTIFICATIONS_ON);
-                addToggleMenuItem($.Config.I_CONNECTED, $.Config.O_CONNECTED_ON);
-                addToggleMenuItem($.Config.I_HEART_RATE, $.Config.O_HEART_RATE_ON);
-                addToggleMenuItem($.Config.I_RECOVERY_TIME, $.Config.O_RECOVERY_TIME_ON);
+                addToggleMenuItem($.Config.I_ALARMS);
+                addToggleMenuItem($.Config.I_NOTIFICATIONS);
+                addToggleMenuItem($.Config.I_CONNECTED);
+                addToggleMenuItem($.Config.I_HEART_RATE);
+                addToggleMenuItem($.Config.I_RECOVERY_TIME);
                 addMenuItem($.Config.I_DARK_MODE);
                 //Fallthrough
             case $.Config.I_DARK_MODE:
                 // Add menu items for the dark mode on and off times only if dark mode is set to "Scheduled"
-                var dm = $.config.getValue($.Config.I_DARK_MODE);
-                if ($.Config.O_DARK_MODE_SCHEDULED == dm) {
+                if (:DarkModeScheduled == $.config.getOption($.Config.I_DARK_MODE)) {
                     addMenuItem($.Config.I_DM_ON);
                     addMenuItem($.Config.I_DM_OFF);
                 }
                 addMenuItem($.Config.I_HIDE_SECONDS);
-                Menu2.addItem(new WatchUi.MenuItem($.getStringResource(:Done), $.getStringResource(:DoneLabel), $.Config.I_DONE, {}));
-                break;
-            default:
-                System.println("ERROR: SettingsMenu.buildMenu() is not implemented for id = " + id);
+                Menu2.addItem(new WatchUi.MenuItem(Rez.Strings.Done, Rez.Strings.DoneLabel, $.Config.I_DONE, {}));
                 break;
         }
     }
@@ -312,9 +308,6 @@ class SettingsMenu extends WatchUi.Menu2 {
                 deleteAnyItem($.Config.I_HIDE_SECONDS);
                 deleteAnyItem($.Config.I_DONE);
                 break;
-            default:
-                System.println("ERROR: SettingsMenu.deleteMenu() is not implemented for id = " + id);
-                break;
         }
     }
 
@@ -324,12 +317,12 @@ class SettingsMenu extends WatchUi.Menu2 {
     }
 
     //! Add a ToggleMenuItem to the menu.
-    private function addToggleMenuItem(item as Config.Item, isEnabled as Number) as Void {
+    private function addToggleMenuItem(item as Config.Item) as Void {
         Menu2.addItem(new WatchUi.ToggleMenuItem(
             $.config.getName(item), 
-            {:enabled=>$.getStringResource(:On), :disabled=>$.getStringResource(:Off)},
+            {:enabled=>Rez.Strings.On, :disabled=>Rez.Strings.Off},
             item, 
-            isEnabled == $.config.getValue(item), 
+            $.config.isEnabled(item), 
             {}
         ));
     }
@@ -394,9 +387,6 @@ class SettingsMenuDelegate extends WatchUi.Menu2InputDelegate {
                 break;
             case $.Config.I_DONE:
                 WatchUi.popView(WatchUi.SLIDE_IMMEDIATE);
-                break;
-            default:
-                System.println("ERROR: SettingsMenuDelegate.onSelect() is not implemented for id = " + id);
                 break;
         }
   	}

--- a/source-legacy/Settings.mc
+++ b/source-legacy/Settings.mc
@@ -338,44 +338,26 @@ class SettingsMenuDelegate extends WatchUi.Menu2InputDelegate {
         WatchUi.popView(WatchUi.SLIDE_IMMEDIATE);
     }
 
-    //! Handle a menu item being selected
-    //! @param menuItem The menu item selected
+    // Handle a menu item being selected
     public function onSelect(menuItem as MenuItem) as Void {
         var id = menuItem.getId() as Config.Item;
-        switch (id) {
-            case $.Config.I_DATE_DISPLAY:
-            case $.Config.I_HIDE_SECONDS:
-                // Advance to the next option and show the selected option as the sub label
-                $.config.setNext(id);
-                menuItem.setSubLabel($.config.getLabel(id));
-                break;
-            case $.Config.I_BATTERY:
-            case $.Config.I_DARK_MODE:
-                // Advance to the next option and show the selected option as the sub label
-                $.config.setNext(id);
-                menuItem.setSubLabel($.config.getLabel(id));
+        if ($.Config.I_DONE == id) {
+            WatchUi.popView(WatchUi.SLIDE_IMMEDIATE);
+        } else if (id >= $.Config.I_ALARMS) { // toggle items
+            // Toggle the two possible configuration values
+            $.config.setNext(id);
+        } else if (id < $.Config.I_DM_ON) { // list items
+            // Advance to the next option and show the selected option as the sub label
+            $.config.setNext(id);
+            menuItem.setSubLabel($.config.getLabel(id));
+            if ($.Config.I_BATTERY == id or $.Config.I_DARK_MODE == id) {
                 // Delete all the following menu items, rebuild the menu with only the items required
                 _menu.deleteMenu(id);
                 _menu.buildMenu(id);
-                break;
-            case $.Config.I_ALARMS:
-            case $.Config.I_NOTIFICATIONS:
-            case $.Config.I_CONNECTED:
-            case $.Config.I_HEART_RATE:
-            case $.Config.I_RECOVERY_TIME:
-            case $.Config.I_BATTERY_PCT:
-            case $.Config.I_BATTERY_DAYS:
-                // Toggle the two possible configuration values
-                $.config.setNext(id);
-                break;
-            case $.Config.I_DM_ON:
-            case $.Config.I_DM_OFF:
-                // Let the user select the time
-                WatchUi.pushView(new TimePicker(id), new TimePickerDelegate(id), WatchUi.SLIDE_IMMEDIATE);
-                break;
-            case $.Config.I_DONE:
-                WatchUi.popView(WatchUi.SLIDE_IMMEDIATE);
-                break;
+            }
+        } else { // I_DM_ON or I_DM_OFF
+            // Let the user select the time
+            WatchUi.pushView(new TimePicker(id), new TimePickerDelegate(id), WatchUi.SLIDE_IMMEDIATE);
         }
   	}
 } // class SettingsMenuDelegate

--- a/source-modern/ClockView.mc
+++ b/source-modern/ClockView.mc
@@ -280,13 +280,13 @@ class ClockView extends WatchUi.WatchFace {
             colorMode = setColorMode(deviceSettings.doNotDisturb, clockTime.hour, clockTime.min);
 
             // Note: Whether 3D effects are supported by the device is also ensured by getValue().
-            _show3dEffects = $.Config.O_3D_EFFECTS_ON == $.config.getValue($.Config.I_3D_EFFECTS) and M_LIGHT == colorMode;
+            _show3dEffects = $.config.isEnabled($.Config.I_3D_EFFECTS) and M_LIGHT == colorMode;
             _secondShadowLayer.setVisible(_show3dEffects and isAwake);
 
             // Handle the setting to disable the second hand in sleep mode after some time
-            var secondsOption = $.config.getValue($.Config.I_HIDE_SECONDS);
-            _hideSecondHand = $.Config.O_HIDE_SECONDS_ALWAYS == secondsOption 
-                or ($.Config.O_HIDE_SECONDS_IN_DM == secondsOption and M_DARK == colorMode);
+            var secondsOption = $.config.getOption($.Config.I_HIDE_SECONDS);
+            _hideSecondHand = :HideSecondsAlways == secondsOption 
+                or (:HideSecondsInDm == secondsOption and M_DARK == colorMode);
             _secondLayer.setVisible(_sleepTimer != 0 or !_hideSecondHand);
 
             // Draw the background
@@ -540,21 +540,21 @@ class ClockView extends WatchUi.WatchFace {
 
     private function setColorMode(doNotDisturb as Boolean, hour as Number, min as Number) as Number {
         var colorMode = M_LIGHT;
-        switch ($.config.getValue($.Config.I_DARK_MODE)) {
-            case $.Config.O_DARK_MODE_SCHEDULED:
+        switch ($.config.getOption($.Config.I_DARK_MODE)) {
+            case :DarkModeScheduled:
                 colorMode = M_LIGHT;
                 var time = hour * 60 + min;
                 if (time >= $.config.getValue($.Config.I_DM_ON) or time < $.config.getValue($.Config.I_DM_OFF)) {
                     colorMode = M_DARK;
                 }
                 break;
-            case $.Config.O_DARK_MODE_OFF:
+            case :Off:
                 colorMode = M_LIGHT;
                 break;
-            case $.Config.O_DARK_MODE_ON:
+            case :On:
                 colorMode = M_DARK;
                 break;
-            case $.Config.O_DARK_MODE_IN_DND:
+            case :DarkModeInDnD:
                 colorMode = doNotDisturb ? M_DARK : M_LIGHT;
                 break;
         }

--- a/source-modern/ClockView.mc
+++ b/source-modern/ClockView.mc
@@ -539,38 +539,25 @@ class ClockView extends WatchUi.WatchFace {
     }
 
     private function setColorMode(doNotDisturb as Boolean, hour as Number, min as Number) as Number {
+        var darkMode = $.config.getOption($.Config.I_DARK_MODE);
         var colorMode = M_LIGHT;
-        switch ($.config.getOption($.Config.I_DARK_MODE)) {
-            case :DarkModeScheduled:
-                colorMode = M_LIGHT;
-                var time = hour * 60 + min;
-                if (time >= $.config.getValue($.Config.I_DM_ON) or time < $.config.getValue($.Config.I_DM_OFF)) {
-                    colorMode = M_DARK;
-                }
-                break;
-            case :Off:
-                colorMode = M_LIGHT;
-                break;
-            case :On:
+        if (:DarkModeScheduled == darkMode) {
+            var time = hour * 60 + min;
+            if (time >= $.config.getValue($.Config.I_DM_ON) or time < $.config.getValue($.Config.I_DM_OFF)) {
                 colorMode = M_DARK;
-                break;
-            case :DarkModeInDnD:
-                colorMode = doNotDisturb ? M_DARK : M_LIGHT;
-                break;
+            }
+        } else if (   :On == darkMode
+                   or (:DarkModeInDnD == darkMode and doNotDisturb)) {
+            colorMode = M_DARK;
         }
-
-        // In dark mode, adjust colors based on the contrast setting
+        // In dark mode, adjust text color based on the contrast setting
         if (M_DARK == colorMode) {
             var foregroundColor = $.config.getValue($.Config.I_DM_CONTRAST);
             colors[M_DARK][C_FOREGROUND] = foregroundColor;
-            switch (foregroundColor) {
-                case Graphics.COLOR_WHITE:
-                    colors[M_DARK][C_TEXT] = Graphics.COLOR_LT_GRAY;
-                    break;
-                case Graphics.COLOR_LT_GRAY:
-                case Graphics.COLOR_DK_GRAY:
-                    colors[M_DARK][C_TEXT] = Graphics.COLOR_DK_GRAY;
-                    break;
+            if (Graphics.COLOR_WHITE == foregroundColor) {
+                colors[M_DARK][C_TEXT] = Graphics.COLOR_LT_GRAY;
+            } else { // Graphics.COLOR_LT_GRAY or Graphics.COLOR_DK_GRAY
+                colors[M_DARK][C_TEXT] = Graphics.COLOR_DK_GRAY;
             }
         }
         return colorMode;

--- a/source-modern/Settings.mc
+++ b/source-modern/Settings.mc
@@ -37,7 +37,7 @@ function getStringResource(id as Symbol) as String {
 class Config {
     // Configuration item identifiers. Used throughout the app to refer to individual settings.
     // The last one must be I_SIZE, it is used like size(), those after I_SIZE are hacks
-    enum Item { 
+    enum Item {
         I_BATTERY, 
         I_DATE_DISPLAY, 
         I_DARK_MODE, 
@@ -59,6 +59,7 @@ class Config {
         I_DONE, 
         I_ALL 
     }
+
     // Symbols for the configuration item display name resources.
     // Must be in the same sequence as Item, above.
 	private var _itemSymbols as Array<Symbol> = [
@@ -80,27 +81,28 @@ class Config {
         :DmOn, 
         :DmOff
     ] as Array<Symbol>;
+
     // Configuration item labels only used as keys for storing the configuration values.
     // Also must be in the same sequence as Item.
     // Using these for persistent storage, rather than Item, is more robust.
     private var _itemLabels as Array<String> = [
-        "battery", 
-        "dateDisplay", 
-        "darkMode", 
-        "hideSeconds", 
-        "dmContrast", 
-        "alarms", 
-        "notifications", 
-        "connected", 
-        "heartRate", 
-        "recoveryTime",
-        "steps",
-        "moveBar",
-        "3dEffects", 
-        "batteryPct", 
-        "batteryDays", 
-        "dmOn", 
-        "dmOff"
+        "ba", // I_BATTERY
+        "dd", // I_DATE_DISPLAY
+        "dm", // I_DARK_MODE
+        "hs", // I_HIDE_SECONDS
+        "dc", // I_DM_CONTRAST
+        "al", // I_ALARMS
+        "no", // I_NOTIFICATIONS
+        "co", // I_CONNECTED
+        "hr", // I_HEART_RATE
+        "rt", // I_RECOVERY_TIME
+        "st", // I_STEPS
+        "mb", // I_MOVE_BAR
+        "3d", // I_3D_EFFECTS
+        "bp", // I_BATTERY_PCT
+        "bd", // I_BATTERY_DAYS
+        "dn", // I_DM_ON
+        "df"  // I_DM_OFF
     ] as Array<String>;
 
     // Option labels for list items. One array of symbols for each of the them. These inner arrays are accessed

--- a/source-modern/Settings.mc
+++ b/source-modern/Settings.mc
@@ -47,7 +47,7 @@ class Config {
         I_DM_CONTRAST,
         I_DM_ON, // the first item that is not a list item
         I_DM_OFF, 
-        I_ALARMS, // the first of the on/off switches (see _defaults)
+        I_ALARMS, // the first toggle item (see _defaults)
         I_NOTIFICATIONS,
         I_CONNECTED,
         I_HEART_RATE,
@@ -117,7 +117,7 @@ class Config {
         [:DmContrastLtGray, :DmContrastDkGray, :DmContrastWhite] // I_DM_CONTRAST
      ] as Array< Array<Symbol> >;
 
-    private var _defaults as Number = 0x4280; // 0b0 0100 0010 1000 0000 default values for on/off settings, each bit is one
+    private var _defaults as Number = 0x4280; // 0b0 0100 0010 1000 0000 default values for toggle items, each bit is one
 
     private var _values as Array<Number> = new Array<Number>[I_SIZE]; // Values for the configuration items
     private var _hasAlpha as Boolean; // Indicates if the device supports an alpha channel; required for the 3D effects
@@ -130,46 +130,28 @@ class Config {
         // Read the configuration values from persistent storage 
         for (var id = 0; id < I_SIZE; id++) {
             var value = Storage.getValue(_itemLabels[id]) as Number;
-            switch (id) {
-                case I_DM_ON:
-                    if (null == value or value < 0 or value > 1439) {
-                        value = 1320; // Default time to turn dark mode on: 22:00
-                    }
-                    break;
-                case I_DM_OFF:
-                    if (null == value or value < 0 or value > 1439) {
-                        value = 420; // Default time to turn dark more off: 07:00
-                    }
-                    break;
-                case I_3D_EFFECTS:
-                    if (null == value) { 
-                        value = (_defaults & (1 << id)) >> id;
-                    }
-                    // Make sure the value is compatible with the device capabilities, so the watchface code can rely on getValue() alone.
-                    if (!_hasAlpha) { value = 0; }
-                    break;
-                case I_BATTERY_DAYS:
-                    if (null == value) { 
-                        value = (_defaults & (1 << id)) >> id;
-                    }
-                    // Make sure the value is compatible with the device capabilities, so the watchface code can rely on getValue() alone.
-                    if (!_hasBatteryInDays) { value = 0; }
-                    break;
-                case I_ALARMS:
-                case I_NOTIFICATIONS:
-                case I_CONNECTED:
-                case I_HEART_RATE:
-                case I_RECOVERY_TIME:
-                case I_STEPS:
-                case I_MOVE_BAR:
-                case I_BATTERY_PCT:
-                    if (null == value) { 
-                        value = (_defaults & (1 << id)) >> id; 
-                    }
-                    break;
-                default:
-                    if (null == value) { value = 0; }
-                    break;
+            if (id >= I_ALARMS) { // toggle items
+                if (null == value) { 
+                    value = (_defaults & (1 << id)) >> id;
+                }
+                // Make sure the value is compatible with the device capabilities, so the watchface code can rely on getValue() alone.
+                if (I_BATTERY_DAYS == id and !_hasBatteryInDays) { 
+                    value = 0;
+                }
+                if (I_3D_EFFECTS == id and !_hasAlpha) { 
+                    value = 0; 
+                }
+            } else if (id < I_DM_ON) { // list items
+                if (null == value) { 
+                    value = 0;
+                }
+            } else { // I_DM_ON or I_DM_OFF
+                if (I_DM_ON == id and (null == value or value < 0 or value > 1439)) {
+                    value = 1320; // Default time to turn dark mode on: 22:00
+                }
+                if (I_DM_OFF == id and (null == value or value < 0 or value > 1439)) {
+                    value = 420; // Default time to turn dark more off: 07:00
+                }
             }
             _values[id] = value;
         }
@@ -194,7 +176,7 @@ class Config {
     public function getOption(id as Item) as Symbol or String {
         var ret;
         var value = _values[id as Number];
-        if (id >= I_ALARMS) {
+        if (id >= I_ALARMS) { // toggle items
             ret = isEnabled(id) ? :On : :Off;            
         } else if (id < I_DM_ON) { // list items
             var opts = _options[id as Number] as Array<Symbol>;

--- a/source-modern/Settings.mc
+++ b/source-modern/Settings.mc
@@ -383,55 +383,31 @@ class SettingsMenuDelegate extends WatchUi.Menu2InputDelegate {
         WatchUi.popView(WatchUi.SLIDE_IMMEDIATE);
     }
 
-    //! Handle a menu item being selected
-    //! @param menuItem The menu item selected
+    // Handle a menu item being selected
     public function onSelect(menuItem as MenuItem) as Void {
         var id = menuItem.getId() as Config.Item;
-        switch (id) {
-            case $.Config.I_DATE_DISPLAY:
-            case $.Config.I_HIDE_SECONDS:
-                // Advance to the next option and show the selected option as the sub label
-                $.config.setNext(id);
-                menuItem.setSubLabel($.config.getLabel(id));
-                break;
-            case $.Config.I_DM_CONTRAST:
-                // Advance to the next option and show the selected option as the sub label
-                $.config.setNext(id);
-                menuItem.setSubLabel($.config.getLabel(id));
-                // Update the color of the icon
-                var menuIcon = menuItem.getIcon() as MenuIcon;
-                menuIcon.setColor($.config.getValue(id));
-                break;
-            case $.Config.I_BATTERY:
-            case $.Config.I_DARK_MODE:
-                // Advance to the next option and show the selected option as the sub label
-                $.config.setNext(id);
-                menuItem.setSubLabel($.config.getLabel(id));
+        if ($.Config.I_DONE == id) {
+            WatchUi.popView(WatchUi.SLIDE_IMMEDIATE);
+        } else if (id >= $.Config.I_ALARMS) { // toggle items
+            // Toggle the two possible configuration values
+            $.config.setNext(id);
+        } else if (id < $.Config.I_DM_ON) { // list items
+            // Advance to the next option and show the selected option as the sub label
+            $.config.setNext(id);
+            menuItem.setSubLabel($.config.getLabel(id));
+            if ($.Config.I_BATTERY == id or $.Config.I_DARK_MODE == id) {
                 // Delete all the following menu items, rebuild the menu with only the items required
                 _menu.deleteMenu(id);
                 _menu.buildMenu(id);
-                break;
-            case $.Config.I_ALARMS:
-            case $.Config.I_NOTIFICATIONS:
-            case $.Config.I_CONNECTED:
-            case $.Config.I_HEART_RATE:
-            case $.Config.I_RECOVERY_TIME:
-            case $.Config.I_STEPS:
-            case $.Config.I_MOVE_BAR:
-            case $.Config.I_3D_EFFECTS:
-            case $.Config.I_BATTERY_PCT:
-            case $.Config.I_BATTERY_DAYS:
-                // Toggle the two possible configuration values
-                $.config.setNext(id);
-                break;
-            case $.Config.I_DM_ON:
-            case $.Config.I_DM_OFF:
-                // Let the user select the time
-                WatchUi.pushView(new TimePicker(id), new TimePickerDelegate(id), WatchUi.SLIDE_IMMEDIATE);
-                break;
-            case $.Config.I_DONE:
-                WatchUi.popView(WatchUi.SLIDE_IMMEDIATE);
-                break;
+            }
+            if ($.Config.I_DM_CONTRAST == id) {
+                // Update the color of the icon
+                var menuIcon = menuItem.getIcon() as MenuIcon;
+                menuIcon.setColor($.config.getValue(id));
+            }
+        } else { // I_DM_ON or I_DM_OFF
+            // Let the user select the time
+            WatchUi.pushView(new TimePicker(id), new TimePickerDelegate(id), WatchUi.SLIDE_IMMEDIATE);
         }
   	}
 } // class SettingsMenuDelegate

--- a/source-modern/Settings.mc
+++ b/source-modern/Settings.mc
@@ -44,8 +44,8 @@ class Config {
         I_DATE_DISPLAY, 
         I_DARK_MODE, 
         I_HIDE_SECONDS, 
-        I_DM_CONTRAST, // the last list item, add new ones before this
-        I_DM_ON, 
+        I_DM_CONTRAST,
+        I_DM_ON, // the first item that is not a list item
         I_DM_OFF, 
         I_ALARMS, // the first of the on/off switches (see _defaults)
         I_NOTIFICATIONS,
@@ -196,7 +196,7 @@ class Config {
         var value = _values[id as Number];
         if (id >= I_ALARMS) {
             ret = isEnabled(id) ? :On : :Off;            
-        } else if (id <= I_DM_CONTRAST) {
+        } else if (id < I_DM_ON) { // list items
             var opts = _options[id as Number] as Array<Symbol>;
             ret = opts[value];
         } else { // if (I_DM_ON == id or I_DM_OFF == id) {
@@ -235,8 +235,8 @@ class Config {
 
     // Advance the setting to the next value. Does not make sense for I_DM_ON, I_DM_OFF.
     public function setNext(id as Item) as Void {
-        var d = 2;
-        if (id <= I_DM_CONTRAST) {
+        var d = 2; // toggle items have two options
+        if (id < I_DM_ON) { // for list items get the number of options
             d = _options[id as Number].size();
         }
         var value = (_values[id as Number] + 1) % d;

--- a/source-modern/Settings.mc
+++ b/source-modern/Settings.mc
@@ -27,6 +27,12 @@ import Toybox.WatchUi;
 //! Global variable that keeps track of the settings and makes them available to the app.
 var config as Config = new Config();
 
+// Global helper function to load string resources, just to keep the code simpler and see only one compiler warning. 
+// Decided not to cache the strings.
+function getStringResource(id as Symbol) as String {
+    return WatchUi.loadResource(Rez.Strings[id] as Symbol) as String;
+}
+
 //! This class maintains application settings and synchronises them to persistent storage.
 class Config {
     // Configuration item identifiers. Used throughout the app to refer to individual settings.
@@ -190,6 +196,15 @@ class Config {
         return ret;
     }
 
+    // Return a string resource for the current value of the setting
+    public function getLabel(id as Item) as String {
+        var label = getOption(id);
+        if (label instanceof Lang.Symbol) {
+            label = $.getStringResource(getOption(id) as Symbol);
+        }
+        return label;
+    }
+
     // Return true if the setting is enabled, else false.
     // Does not make sense for I_DM_CONTRAST, I_DM_ON and I_DM_OFF.
     public function isEnabled(id as Item) as Boolean {
@@ -211,9 +226,9 @@ class Config {
         return value;
     }
 
-    // Return the resource identifier of the specified setting
-    public function getSymbol(id as Item) as Symbol {
-        return _itemSymbols[id as Number];
+    // Return a string resource for the setting
+    public function getName(id as Item) as String {
+        return $.getStringResource(_itemSymbols[id as Number] as Symbol);
     }
 
     // Advance the setting to the next value. Does not make sense for I_DM_ON, I_DM_OFF
@@ -248,7 +263,7 @@ class Config {
 class SettingsMenu extends WatchUi.Menu2 {
     //! Constructor
     public function initialize() {
-        Menu2.initialize({:title=>:Settings});
+        Menu2.initialize({:title=>Rez.Strings.Settings});
         buildMenu($.Config.I_ALL);
     }
 
@@ -259,12 +274,12 @@ class SettingsMenu extends WatchUi.Menu2 {
         var idx = findItemById($.Config.I_DM_ON);
         if (-1 != idx) {
             var menuItem = getItem(idx) as MenuItem;
-            menuItem.setSubLabel($.config.getOption($.Config.I_DM_ON));
+            menuItem.setSubLabel($.config.getLabel($.Config.I_DM_ON));
         }
         idx = findItemById($.Config.I_DM_OFF);
         if (-1 != idx) {
             var menuItem = getItem(idx) as MenuItem;
-            menuItem.setSubLabel($.config.getOption($.Config.I_DM_OFF));
+            menuItem.setSubLabel($.config.getLabel($.Config.I_DM_OFF));
         }
     }
 
@@ -301,8 +316,8 @@ class SettingsMenu extends WatchUi.Menu2 {
                 // Add the menu item for dark mode contrast only if dark mode is not set to "Off"
                 if ($.config.isEnabled($.Config.I_DARK_MODE)) {
                     Menu2.addItem(new WatchUi.IconMenuItem(
-                        $.config.getSymbol($.Config.I_DM_CONTRAST), 
-                        $.config.getOption($.Config.I_DM_CONTRAST), 
+                        $.config.getName($.Config.I_DM_CONTRAST), 
+                        $.config.getLabel($.Config.I_DM_CONTRAST), 
                         $.Config.I_DM_CONTRAST,
                         new MenuIcon($.config.getValue($.Config.I_DM_CONTRAST)),
                         {}
@@ -312,7 +327,7 @@ class SettingsMenu extends WatchUi.Menu2 {
                 if ($.config.hasAlpha()) {
                     addToggleMenuItem($.Config.I_3D_EFFECTS); 
                 }
-                Menu2.addItem(new WatchUi.MenuItem(:Done, :DoneLabel, $.Config.I_DONE, {}));
+                Menu2.addItem(new WatchUi.MenuItem(Rez.Strings.Done, Rez.Strings.DoneLabel, $.Config.I_DONE, {}));
                 break;
         }
     }
@@ -347,14 +362,14 @@ class SettingsMenu extends WatchUi.Menu2 {
 
     //! Add a MenuItem to the menu.
     private function addMenuItem(item as Config.Item) as Void {
-        Menu2.addItem(new WatchUi.MenuItem($.config.getSymbol(item), $.config.getOption(item), item, {}));
+        Menu2.addItem(new WatchUi.MenuItem($.config.getName(item), $.config.getLabel(item), item, {}));
     }
 
     //! Add a ToggleMenuItem to the menu.
     private function addToggleMenuItem(item as Config.Item) as Void {
         Menu2.addItem(new WatchUi.ToggleMenuItem(
-            $.config.getSymbol(item), 
-            {:enabled=>:On, :disabled=>:Off},
+            $.config.getName(item), 
+            {:enabled=>Rez.Strings.On, :disabled=>Rez.Strings.Off},
             item, 
             $.config.isEnabled(item), 
             {}
@@ -393,12 +408,12 @@ class SettingsMenuDelegate extends WatchUi.Menu2InputDelegate {
             case $.Config.I_HIDE_SECONDS:
                 // Advance to the next option and show the selected option as the sub label
                 $.config.setNext(id);
-                menuItem.setSubLabel($.config.getOption(id));
+                menuItem.setSubLabel($.config.getLabel(id));
                 break;
             case $.Config.I_DM_CONTRAST:
                 // Advance to the next option and show the selected option as the sub label
                 $.config.setNext(id);
-                menuItem.setSubLabel($.config.getOption(id));
+                menuItem.setSubLabel($.config.getLabel(id));
                 // Update the color of the icon
                 var menuIcon = menuItem.getIcon() as MenuIcon;
                 menuIcon.setColor($.config.getValue(id));
@@ -407,7 +422,7 @@ class SettingsMenuDelegate extends WatchUi.Menu2InputDelegate {
             case $.Config.I_DARK_MODE:
                 // Advance to the next option and show the selected option as the sub label
                 $.config.setNext(id);
-                menuItem.setSubLabel($.config.getOption(id));
+                menuItem.setSubLabel($.config.getLabel(id));
                 // Delete all the following menu items, rebuild the menu with only the items required
                 _menu.deleteMenu(id);
                 _menu.buildMenu(id);

--- a/source-modern/Settings.mc
+++ b/source-modern/Settings.mc
@@ -177,7 +177,7 @@ class Config {
 
     // Return a string resource for the setting (the name of the setting).
     public function getName(id as Item) as String {
-        return $.getStringResource(_itemSymbols[id as Number] as Symbol);
+        return $.getStringResource(_itemSymbols[id as Number]);
     }
 
     // Return a string resource for the current value of the setting (the name of the option).

--- a/source-modern/Settings.mc
+++ b/source-modern/Settings.mc
@@ -109,9 +109,9 @@ class Config {
         [:DmContrastLtGray, :DmContrastDkGray, :DmContrastWhite] // I_DM_CONTRAST
      ] as Array< Array<Symbol> >;
 
-    private var _values as Array<Number> = new Array<Number>[I_SIZE]; // Values for the configuration items
     private var _defaults as Number = 0x4280; // 0b0 0100 0010 1000 0000 default values of on/off settings, each bit is one
 
+    private var _values as Array<Number> = new Array<Number>[I_SIZE]; // Values for the configuration items
     private var _hasAlpha as Boolean; // Indicates if the device supports an alpha channel; required for the 3D effects
     private var _hasBatteryInDays as Boolean; // Indicates if the device provides battery in days estimates
 

--- a/source-modern/Settings.mc
+++ b/source-modern/Settings.mc
@@ -40,6 +40,9 @@ class Config {
     enum Item { 
         I_BATTERY, 
         I_DATE_DISPLAY, 
+        I_DARK_MODE, 
+        I_HIDE_SECONDS, 
+        I_DM_CONTRAST, 
         I_ALARMS,
         I_NOTIFICATIONS,
         I_CONNECTED,
@@ -47,9 +50,6 @@ class Config {
         I_RECOVERY_TIME,
         I_STEPS,
         I_MOVE_BAR,
-        I_DARK_MODE, 
-        I_DM_CONTRAST, 
-        I_HIDE_SECONDS, 
         I_3D_EFFECTS, 
         I_BATTERY_PCT, 
         I_BATTERY_DAYS, 
@@ -64,6 +64,9 @@ class Config {
 	private var _itemSymbols as Array<Symbol> = [
         :Battery, 
         :DateDisplay, 
+        :DarkMode, 
+        :HideSeconds, 
+        :DmContrast, 
         :Alarms,
         :Notifications,
         :Connected,
@@ -71,9 +74,6 @@ class Config {
         :RecoveryTime,
         :Steps,
         :MoveBar,
-        :DarkMode, 
-        :DmContrast, 
-        :HideSeconds, 
         :Shadows, 
         :BatteryPct, 
         :BatteryDays, 
@@ -86,6 +86,9 @@ class Config {
     private var _itemLabels as Array<String> = [
         "battery", 
         "dateDisplay", 
+        "darkMode", 
+        "hideSeconds", 
+        "dmContrast", 
         "alarms", 
         "notifications", 
         "connected", 
@@ -93,9 +96,6 @@ class Config {
         "recoveryTime",
         "steps",
         "moveBar",
-        "darkMode", 
-        "dmContrast", 
-        "hideSeconds", 
         "3dEffects", 
         "batteryPct", 
         "batteryDays", 
@@ -103,9 +103,24 @@ class Config {
         "dmOff"
     ] as Array<String>;
 
+    // Option labels for list items. One array of symbols for each of the them. These inner arrays are accessed
+    // using Item enums, so list items need to be the first ones in that enum and in the same order.
+    private var _labels as Array< Array<Symbol> > = [
+        [:Off, :BatteryClassicWarnings, :BatteryModernWarnings, :BatteryClassic, :BatteryModern, :BatteryHybrid], // I_BATTERY
+        [:Off, :DateDisplayDayOnly, :DateDisplayWeekdayAndDay], // I_DATE_DISPLAY
+        [:DarkModeScheduled, :Off, :On, :DarkModeInDnD], // I_DARK_MODE
+        [:HideSecondsInDm, :HideSecondsAlways, :HideSecondsNever], // I_HIDE_SECONDS
+        [:DmContrastLtGray, :DmContrastDkGray, :DmContrastWhite] // I_DM_CONTRAST
+     ] as Array< Array<Symbol> >;
+
+    // Colors for the dark mode contrast icon menu item. The index (0, 1 or 2) is stored, but getValue() returns the color.
+    static const O_DM_CONTRAST as Array<Number> = [Graphics.COLOR_LT_GRAY, Graphics.COLOR_DK_GRAY, Graphics.COLOR_WHITE] as Array<Number>;
+
     // Options for list and toggle configuration items. Using enums, the compiler can help detect issues like typos or outdated values.
     enum { O_BATTERY_OFF, O_BATTERY_CLASSIC_WARN, O_BATTERY_MODERN_WARN, O_BATTERY_CLASSIC, O_BATTERY_MODERN, O_BATTERY_HYBRID }
     enum { O_DATE_DISPLAY_OFF, O_DATE_DISPLAY_DAY_ONLY, O_DATE_DISPLAY_WEEKDAY_AND_DAY }
+    enum { O_DARK_MODE_SCHEDULED, O_DARK_MODE_OFF, O_DARK_MODE_ON, O_DARK_MODE_IN_DND }
+    enum { O_HIDE_SECONDS_IN_DM, O_HIDE_SECONDS_ALWAYS, O_HIDE_SECONDS_NEVER }
     enum { O_ALARMS_ON, O_ALARMS_OFF } // Default: On
     enum { O_NOTIFICATIONS_OFF, O_NOTIFICATIONS_ON } // Default: Off
     enum { O_CONNECTED_ON, O_CONNECTED_OFF } // Default: On
@@ -113,22 +128,9 @@ class Config {
     enum { O_RECOVERY_TIME_OFF, O_RECOVERY_TIME_ON } // Default: Off
     enum { O_STEPS_OFF, O_STEPS_ON } // Default: Off
     enum { O_MOVE_BAR_OFF, O_MOVE_BAR_ON } // Default: Off
-    enum { O_DARK_MODE_SCHEDULED, O_DARK_MODE_OFF, O_DARK_MODE_ON, O_DARK_MODE_IN_DND }
-    enum { O_HIDE_SECONDS_IN_DM, O_HIDE_SECONDS_ALWAYS, O_HIDE_SECONDS_NEVER }
     enum { O_3D_EFFECTS_ON, O_3D_EFFECTS_OFF } // Default: On
     enum { O_BATTERY_PCT_OFF, O_BATTERY_PCT_ON } // Default: Off
     enum { O_BATTERY_DAYS_OFF, O_BATTERY_DAYS_ON } // Default: Off
-    // Colors for the dark mode contrast icon menu item. The index (0, 1 or 2) is stored, but getValue() returns the color.
-    static const O_DM_CONTRAST as Array<Number> = [Graphics.COLOR_LT_GRAY, Graphics.COLOR_DK_GRAY, Graphics.COLOR_WHITE] as Array<Number>;
-
-    // Option labels for list items. One for each of the enum values above and in the same order.
-    private var _labels as Dictionary<Item, Array<Symbol> > = {
-        I_BATTERY      => [:Off, :BatteryClassicWarnings, :BatteryModernWarnings, :BatteryClassic, :BatteryModern, :BatteryHybrid],
-        I_DATE_DISPLAY => [:Off, :DateDisplayDayOnly, :DateDisplayWeekdayAndDay],
-        I_DARK_MODE    => [:DarkModeScheduled, :Off, :On, :DarkModeInDnD],
-        I_DM_CONTRAST  => [:DmContrastLtGray, :DmContrastDkGray, :DmContrastWhite],
-        I_HIDE_SECONDS => [:HideSecondsInDm, :HideSecondsAlways, :HideSecondsNever]
-    } as Dictionary<Item, Array<Symbol> >;
 
     private var _values as Array<Number> = new Array<Number>[I_SIZE]; ;  // Values for the configuration items
     private var _hasAlpha as Boolean; // Indicates if the device supports an alpha channel; required for the 3D effects
@@ -180,9 +182,9 @@ class Config {
             case I_BATTERY:
             case I_DATE_DISPLAY:
             case I_DARK_MODE:
-            case I_DM_CONTRAST:
             case I_HIDE_SECONDS:
-                var label = _labels[id] as Array<Symbol>;
+            case I_DM_CONTRAST:
+                var label = _labels[id as Number] as Array<Symbol>;
                 option = $.getStringResource(label[value]);
                 break;
             case I_DM_ON:
@@ -231,9 +233,9 @@ class Config {
             case I_BATTERY:
             case I_DATE_DISPLAY:
             case I_DARK_MODE:
-            case I_DM_CONTRAST:
             case I_HIDE_SECONDS:
-                var label = _labels[id] as Array<Symbol>;
+            case I_DM_CONTRAST:
+                var label = _labels[id as Number] as Array<Symbol>;
                 _values[id as Number] = (value + 1) % label.size();
                 Storage.setValue(_itemLabels[id as Number], _values[id as Number]);
                 break;

--- a/source-modern/Settings.mc
+++ b/source-modern/Settings.mc
@@ -130,7 +130,7 @@ class Config {
         I_HIDE_SECONDS => [:HideSecondsInDm, :HideSecondsAlways, :HideSecondsNever]
     } as Dictionary<Item, Array<Symbol> >;
 
-    private var _values as Dictionary<Item, Number>;  // Values for the configuration items
+    private var _values as Array<Number> = new Array<Number>[I_SIZE]; ;  // Values for the configuration items
     private var _hasAlpha as Boolean; // Indicates if the device supports an alpha channel; required for the 3D effects
     private var _hasBatteryInDays as Boolean; // Indicates if the device provides battery in days estimates
 
@@ -138,7 +138,6 @@ class Config {
     public function initialize() {
         _hasAlpha = (Graphics has :createColor) and (Graphics.Dc has :setFill); // Both should be available from API Level 4.0.0, but the Venu Sq 2 only has :createColor
         _hasBatteryInDays = (System.Stats has :batteryInDays);
-        _values = {} as Dictionary<Item, Number>;
         // Read the configuration values from persistent storage 
         for (var id = 0; id < I_SIZE; id++) {
             var value = Storage.getValue(_itemLabels[id]) as Number;
@@ -167,7 +166,7 @@ class Config {
                     if (null == value) { value = 0; }
                     break;
             }
-            _values[id as Item] = value;
+            _values[id] = value;
         }
     }
 
@@ -176,7 +175,7 @@ class Config {
     //!@return Label of the currently selected option
     public function getLabel(id as Item) as String {
         var option = "";
-        var value = _values[id];
+        var value = _values[id as Number];
         switch (id) {
             case I_BATTERY:
             case I_DATE_DISPLAY:
@@ -208,7 +207,7 @@ class Config {
     //!@param id Setting
     //!@return The current value of the setting
     public function getValue(id as Item) as Number {
-        var value = _values[id] as Number;
+        var value = _values[id as Number];
         switch (id) {
             case I_DM_CONTRAST:
                 value = O_DM_CONTRAST[value];
@@ -227,7 +226,7 @@ class Config {
     //! Advance the setting to the next value.
     //!@param id Setting
     public function setNext(id as Item) as Void {
-        var value = _values[id];
+        var value = _values[id as Number];
         switch (id) {
             case I_BATTERY:
             case I_DATE_DISPLAY:
@@ -235,8 +234,8 @@ class Config {
             case I_DM_CONTRAST:
             case I_HIDE_SECONDS:
                 var label = _labels[id] as Array<Symbol>;
-                _values[id] = (value as Number + 1) % label.size();
-                Storage.setValue(_itemLabels[id as Number], _values[id]);
+                _values[id as Number] = (value + 1) % label.size();
+                Storage.setValue(_itemLabels[id as Number], _values[id as Number]);
                 break;
             case I_ALARMS:
             case I_NOTIFICATIONS:
@@ -248,8 +247,8 @@ class Config {
             case I_3D_EFFECTS:
             case I_BATTERY_PCT:
             case I_BATTERY_DAYS:
-                _values[id] = (value as Number + 1) % 2;
-                Storage.setValue(_itemLabels[id as Number], _values[id]);
+                _values[id as Number] = (value + 1) % 2;
+                Storage.setValue(_itemLabels[id as Number], _values[id as Number]);
                 break;
             default:
                 System.println("ERROR: Config.setNext() is not implemented for id = " + id);
@@ -261,8 +260,8 @@ class Config {
         switch (id) {
             case I_DM_ON:
             case I_DM_OFF:
-                _values[id] = value;
-                Storage.setValue(_itemLabels[id as Number], _values[id]);
+                _values[id as Number] = value;
+                Storage.setValue(_itemLabels[id as Number], _values[id as Number]);
                 break;
             default:
                 System.println("ERROR: Config.seValue() is not implemented for id = " + id);

--- a/source/Indicators.mc
+++ b/source/Indicators.mc
@@ -689,32 +689,20 @@ class BatteryLevel {
         var color = Graphics.COLOR_GREEN;
         if (level < warnLevel / 2) { color = ClockView.M_LIGHT == ClockView.colorMode ? Graphics.COLOR_ORANGE : Graphics.COLOR_YELLOW; }
         if (level < warnLevel / 4) { color = Graphics.COLOR_RED; }
-        if (level < warnLevel) {
-            switch (batterySetting) {
-                case :BatteryClassic:
-                case :BatteryClassicWarnings:
-                    drawClassicBatteryIndicator(dc, xpos, ypos, level, levelInDays, ClockView.colorMode, color);
-                    ret = true;
-                    break;
-                case :BatteryModern:
-                case :BatteryModernWarnings:
-                case :BatteryHybrid:
-                    drawModernBatteryIndicator(dc, xpos, ypos, level, levelInDays, color);
-                    ret = true;
-                    break;
-            }
-        } else {
-            switch (batterySetting) {
-                case :BatteryClassic:
-                case :BatteryHybrid:
-                    drawClassicBatteryIndicator(dc, xpos, ypos, level, levelInDays, ClockView.colorMode, color);
-                    ret = true;
-                    break;
-                case :BatteryModern:
-                    drawModernBatteryIndicator(dc, xpos, ypos, level, levelInDays, color);
-                    ret = true;
-                    break;
-            }
+
+        // level \ Setting   Classic ClassicWarnings Hybrid Modern ModernWarnings
+        // < warnLevel          C          C           M      M          M       
+        // >= warnLevel         C          -           C      M          -       
+        if (   :BatteryClassic == batterySetting 
+            or (level < warnLevel and :BatteryClassicWarnings == batterySetting)
+            or (level >= warnLevel and :BatteryHybrid == batterySetting)) {
+            drawClassicBatteryIndicator(dc, xpos, ypos, level, levelInDays, ClockView.colorMode, color);
+            ret = true;
+        } else if (   :BatteryModern == batterySetting
+                   or (level < warnLevel and :BatteryModernWarnings == batterySetting)
+                   or (level < warnLevel and :BatteryHybrid == batterySetting)) {
+            drawModernBatteryIndicator(dc, xpos, ypos, level, levelInDays, color);
+            ret = true;
         }
         return ret;
     }

--- a/source/Indicators.mc
+++ b/source/Indicators.mc
@@ -191,7 +191,7 @@ class Indicators {
 
         // Draw the move bar (at a fixed position, so we don't use getIndicatorPosition() here)
         _moveBarDrawn = false;
-        if ($.Config.O_MOVE_BAR_ON == $.config.getValue($.Config.I_MOVE_BAR)) {
+        if ($.config.isEnabled($.Config.I_MOVE_BAR)) {
             _moveBarDrawn = drawMoveBar(dc, _screenCenter[0], _screenCenter[1], _clockRadius, activityInfo.moveBarLevel);
         }
 
@@ -306,41 +306,41 @@ class Indicators {
         var idx = -1;
         switch (indicator) {
             case :recoveryTime:
-                if ($.Config.O_RECOVERY_TIME_ON == $.config.getValue($.Config.I_RECOVERY_TIME)) { 
+                if ($.config.isEnabled($.Config.I_RECOVERY_TIME)) { 
                     idx = 2; 
                 }
                 break;
             case :battery:
-                if ($.config.getValue($.Config.I_BATTERY) > $.Config.O_BATTERY_OFF) {
+                if ($.config.isEnabled($.Config.I_BATTERY)) {
                     idx = _symbolsDrawn ? (_moveBarDrawn ? 14 : 3) : (_moveBarDrawn ? 15 : 4);
                 }
                 break;
             case :symbols:
-                if (   $.Config.O_ALARMS_ON == $.config.getValue($.Config.I_ALARMS)
-                    or $.Config.O_NOTIFICATIONS_ON == $.config.getValue($.Config.I_NOTIFICATIONS)) {
+                if (   $.config.isEnabled($.Config.I_ALARMS)
+                    or $.config.isEnabled($.Config.I_NOTIFICATIONS)) {
                     idx = _moveBarDrawn ? 13 : 5;
                 }
                 break;
             case :phoneConnected:
-                if ($.Config.O_CONNECTED_ON == $.config.getValue($.Config.I_CONNECTED)) { 
+                if ($.config.isEnabled($.Config.I_CONNECTED)) { 
                     idx = 6; 
                 }
                 break;
             case :shortDate:
-                if ($.Config.O_DATE_DISPLAY_DAY_ONLY == $.config.getValue($.Config.I_DATE_DISPLAY)) { 
+                if (:DateDisplayDayOnly == $.config.getOption($.Config.I_DATE_DISPLAY)) { 
                     idx = 7; 
                 }
                 break;
             case :longDate:
-                if ($.Config.O_DATE_DISPLAY_WEEKDAY_AND_DAY == $.config.getValue($.Config.I_DATE_DISPLAY)) {
-                    idx = ($.Config.O_STEPS_ON == $.config.getValue($.Config.I_STEPS) and _batteryDrawn) ? 9 : 8;
+                if (:DateDisplayWeekdayAndDay == $.config.getOption($.Config.I_DATE_DISPLAY)) {
+                    idx = ($.config.isEnabled($.Config.I_STEPS) and _batteryDrawn) ? 9 : 8;
                 }
                 break;
             case :heartRate:
-                if ($.Config.O_HEART_RATE_ON == $.config.getValue($.Config.I_HEART_RATE)) {
+                if ($.config.isEnabled($.Config.I_HEART_RATE)) {
                     idx = 0;
-                    if ($.Config.O_DATE_DISPLAY_DAY_ONLY == $.config.getValue($.Config.I_DATE_DISPLAY)) {
-                        idx = ($.Config.O_STEPS_ON == $.config.getValue($.Config.I_STEPS)) ? 12 : 1;
+                    if (:DateDisplayDayOnly == $.config.getOption($.Config.I_DATE_DISPLAY)) {
+                        idx = ($.config.isEnabled($.Config.I_STEPS)) ? 12 : 1;
                     }
                 }
                 break;
@@ -377,11 +377,11 @@ class Indicators {
                    11: Steps at 6 o'clock, with date (weekday and day format)
                    12: Heart rate indicator at 6 o'clock with steps
                 */
-                if ($.Config.O_STEPS_ON == $.config.getValue($.Config.I_STEPS)) {
-                    if ($.Config.O_DATE_DISPLAY_WEEKDAY_AND_DAY == $.config.getValue($.Config.I_DATE_DISPLAY)) {
+                if ($.config.isEnabled($.Config.I_STEPS)) {
+                    if (:DateDisplayWeekdayAndDay == $.config.getOption($.Config.I_DATE_DISPLAY)) {
                         idx = _batteryDrawn ? 11 : 3;
-                    } else if (    $.Config.O_DATE_DISPLAY_DAY_ONLY == $.config.getValue($.Config.I_DATE_DISPLAY)
-                               and $.Config.O_HEART_RATE_ON == $.config.getValue($.Config.I_HEART_RATE)) {
+                    } else if (    :DateDisplayDayOnly == $.config.getOption($.Config.I_DATE_DISPLAY)
+                               and $.config.isEnabled($.Config.I_HEART_RATE)) {
                         idx = 11;
                     } else {
                         idx = 10;
@@ -455,8 +455,8 @@ class Indicators {
         var icons = "";
         var space = "";
         var indicators = [
-            $.Config.O_ALARMS_ON == $.config.getValue($.Config.I_ALARMS) and alarmCount > 0, 
-            $.Config.O_NOTIFICATIONS_ON == $.config.getValue($.Config.I_NOTIFICATIONS) and notificationCount > 0
+            $.config.isEnabled($.Config.I_ALARMS) and alarmCount > 0, 
+            $.config.isEnabled($.Config.I_NOTIFICATIONS) and notificationCount > 0
         ];
         for (var i = 0; i < indicators.size(); i++) {
             if (indicators[i]) {
@@ -678,7 +678,7 @@ class BatteryLevel {
         ypos as Number
     ) as Boolean {
         var ret = false;
-        var batterySetting = $.config.getValue($.Config.I_BATTERY);
+        var batterySetting = $.config.getOption($.Config.I_BATTERY);
         var systemStats = System.getSystemStats();
         var level = systemStats.battery;
         var levelInDays = 0.0;
@@ -694,26 +694,26 @@ class BatteryLevel {
         if (level < warnLevel / 4) { color = Graphics.COLOR_RED; }
         if (level < warnLevel) {
             switch (batterySetting) {
-                case $.Config.O_BATTERY_CLASSIC:
-                case $.Config.O_BATTERY_CLASSIC_WARN:
+                case :BatteryClassic:
+                case :BatteryClassicWarnings:
                     drawClassicBatteryIndicator(dc, xpos, ypos, level, levelInDays, ClockView.colorMode, color);
                     ret = true;
                     break;
-                case $.Config.O_BATTERY_MODERN:
-                case $.Config.O_BATTERY_MODERN_WARN:
-                case $.Config.O_BATTERY_HYBRID:
+                case :BatteryModern:
+                case :BatteryModernWarnings:
+                case :BatteryHybrid:
                     drawModernBatteryIndicator(dc, xpos, ypos, level, levelInDays, color);
                     ret = true;
                     break;
             }
-        } else if (batterySetting >= $.Config.O_BATTERY_CLASSIC) {
+        } else {
             switch (batterySetting) {
-                case $.Config.O_BATTERY_CLASSIC:
-                case $.Config.O_BATTERY_HYBRID:
+                case :BatteryClassic:
+                case :BatteryHybrid:
                     drawClassicBatteryIndicator(dc, xpos, ypos, level, levelInDays, ClockView.colorMode, color);
                     ret = true;
                     break;
-                case $.Config.O_BATTERY_MODERN:
+                case :BatteryModern:
                     drawModernBatteryIndicator(dc, xpos, ypos, level, levelInDays, color);
                     ret = true;
                     break;
@@ -784,12 +784,12 @@ class BatteryLevel {
         var font = Graphics.FONT_XTINY;
         y += 1; // Looks better aligned on the actual device (fr955) like this
         dc.setColor(ClockView.colors[ClockView.colorMode][ClockView.C_TEXT], Graphics.COLOR_TRANSPARENT);
-        if ($.Config.O_BATTERY_PCT_ON == $.config.getValue($.Config.I_BATTERY_PCT)) {
+        if ($.config.isEnabled($.Config.I_BATTERY_PCT)) {
             var str = (level + 0.5).toNumber() + "% ";
             dc.drawText(x1, y - Graphics.getFontHeight(font)/2, font, str, Graphics.TEXT_JUSTIFY_RIGHT);
         }
         // Note: Whether the device provides battery in days is also ensured by getValue().
-        if ($.Config.O_BATTERY_DAYS_ON == $.config.getValue($.Config.I_BATTERY_DAYS)) {
+        if ($.config.isEnabled($.Config.I_BATTERY_DAYS)) {
             var str = " " + (levelInDays + 0.5).toNumber() + WatchUi.loadResource(Rez.Strings.DayUnit);
             dc.drawText(x2, y - Graphics.getFontHeight(font)/2, font, str, Graphics.TEXT_JUSTIFY_LEFT);
         }

--- a/source/Indicators.mc
+++ b/source/Indicators.mc
@@ -106,8 +106,7 @@ class Indicators {
 
         // Draw alarm and notification indicators
         _symbolsDrawn = false;
-        if (   $.Config.O_ALARMS_ON == $.config.getValue($.Config.I_ALARMS)
-            or $.Config.O_NOTIFICATIONS_ON == $.config.getValue($.Config.I_NOTIFICATIONS)) {
+        if ($.config.isEnabled($.Config.I_ALARMS) or $.config.isEnabled($.Config.I_NOTIFICATIONS)) {
             _symbolsDrawn = drawSymbols(
                 dc,
                 w2, 
@@ -118,7 +117,7 @@ class Indicators {
         }
 
         // Draw the battery level indicator
-        if ($.config.getValue($.Config.I_BATTERY) > $.Config.O_BATTERY_OFF) {
+        if ($.config.isEnabled($.Config.I_BATTERY)) {
             _batteryLevel.draw(
                 dc,
                 w2, 
@@ -129,29 +128,27 @@ class Indicators {
         // Draw the date string
         var info = Gregorian.info(Time.now(), Time.FORMAT_LONG);
         dc.setColor(ClockView.colors[ClockView.colorMode][ClockView.C_TEXT], Graphics.COLOR_TRANSPARENT);
-        switch ($.config.getValue($.Config.I_DATE_DISPLAY)) {
-            case $.Config.O_DATE_DISPLAY_DAY_ONLY: 
-                dc.drawText(
-                    (_width * 0.75).toNumber(), 
-                    (_height * 0.50 - Graphics.getFontHeight(Graphics.FONT_MEDIUM)/2 - 1).toNumber(), 
-                    Graphics.FONT_MEDIUM, 
-                    info.day.format("%02d"), 
-                    Graphics.TEXT_JUSTIFY_CENTER
-                );
-                break;
-            case $.Config.O_DATE_DISPLAY_WEEKDAY_AND_DAY:
-                dc.drawText(
-                    w2, 
-                    (_height * 0.65).toNumber(), 
-                    Graphics.FONT_MEDIUM, 
-                    Lang.format("$1$ $2$", [info.day_of_week, info.day]), 
-                    Graphics.TEXT_JUSTIFY_CENTER
-                );
-                break;
+        var dateDisplay = $.config.getOption($.Config.I_DATE_DISPLAY);
+        if (:DateDisplayDayOnly == dateDisplay) {
+            dc.drawText(
+                (_width * 0.75).toNumber(), 
+                (_height * 0.50 - Graphics.getFontHeight(Graphics.FONT_MEDIUM)/2 - 1).toNumber(), 
+                Graphics.FONT_MEDIUM, 
+                info.day.format("%02d"), 
+                Graphics.TEXT_JUSTIFY_CENTER
+            );
+        } else if (:DateDisplayWeekdayAndDay == dateDisplay) {
+            dc.drawText(
+                w2, 
+                (_height * 0.65).toNumber(), 
+                Graphics.FONT_MEDIUM, 
+                Lang.format("$1$ $2$", [info.day_of_week, info.day]), 
+                Graphics.TEXT_JUSTIFY_CENTER
+            );
         }
 
         // Draw the phone connection indicator on the 6 o'clock tick mark
-        if ($.Config.O_CONNECTED_ON == $.config.getValue($.Config.I_CONNECTED)) { 
+        if ($.config.isEnabled($.Config.I_CONNECTED)) { 
             drawPhoneConnected(
                 dc,
                 w2,
@@ -161,10 +158,10 @@ class Indicators {
         }
 
         // Draw the heart rate indicator
-        if ($.Config.O_HEART_RATE_ON == $.config.getValue($.Config.I_HEART_RATE)) {
+        if ($.config.isEnabled($.Config.I_HEART_RATE)) {
             var xpos = (_width * 0.73).toNumber();
             var ypos = (_height * 0.50).toNumber();
-            if ($.Config.O_DATE_DISPLAY_DAY_ONLY == $.config.getValue($.Config.I_DATE_DISPLAY)) {
+            if (:DateDisplayDayOnly == dateDisplay) {
                 xpos = (_width * 0.48).toNumber();
                 ypos = (_height * 0.75).toNumber();
             }
@@ -172,7 +169,7 @@ class Indicators {
         }
 
         // Draw the recovery time indicator
-        if ($.Config.O_RECOVERY_TIME_ON == $.config.getValue($.Config.I_RECOVERY_TIME)) { 
+        if ($.config.isEnabled($.Config.I_RECOVERY_TIME)) { 
             if (ActivityMonitor.Info has :timeToRecovery) {
                 drawRecoveryTime(
                     dc,

--- a/source/TimePicker.mc
+++ b/source/TimePicker.mc
@@ -36,7 +36,7 @@ class TimePicker extends WatchUi.Picker {
     //! Constructor
     public function initialize(id as Config.Item) {
         var title = new WatchUi.Text({
-            :text=>$.config.getName(id),
+            :text=>$.config.getSymbol(id),
             :font=>Graphics.FONT_SMALL,
             :locX=>WatchUi.LAYOUT_HALIGN_CENTER,
             :locY=>WatchUi.LAYOUT_VALIGN_BOTTOM, 

--- a/source/TimePicker.mc
+++ b/source/TimePicker.mc
@@ -86,16 +86,12 @@ class TimeFactory extends WatchUi.PickerFactory {
         PickerFactory.initialize();
         _mode = mode;
         _is24Hour = is24Hour;
-        _stop = 0;
-        _format = "%d";
-        switch (mode) {
-            case T_HOUR:
-                _stop = _is24Hour ? 23 : 11;
-                break;
-            case T_MINUTE:
-                _stop = 59;
-                _format = "%02d";
-                break;
+        if (T_HOUR == mode) {
+            _stop = _is24Hour ? 23 : 11;
+            _format = "%d";
+        } else { // T_MINUTE == mode
+            _stop = 59;
+            _format = "%02d";
         }
     }
 

--- a/source/TimePicker.mc
+++ b/source/TimePicker.mc
@@ -36,7 +36,7 @@ class TimePicker extends WatchUi.Picker {
     //! Constructor
     public function initialize(id as Config.Item) {
         var title = new WatchUi.Text({
-            :text=>$.config.getSymbol(id),
+            :text=>$.config.getName(id),
             :font=>Graphics.FONT_SMALL,
             :locX=>WatchUi.LAYOUT_HALIGN_CENTER,
             :locY=>WatchUi.LAYOUT_VALIGN_BOTTOM, 


### PR DESCRIPTION
Settings have been refactored to use arrays instead of dictionaries and do away with the setting option enums. Most switch statements throughout the program have been replaced with ifs.

For a fenix6, this reduces the memory footprint by 2kB and the peak memory usage dropped from 99.6% to 97.9% (and 95.8% with the Prettier Monkey-C optimized program).